### PR TITLE
Specify project when listing instances in inventory plugin

### DIFF
--- a/plugins/module_utils/incuscli.py
+++ b/plugins/module_utils/incuscli.py
@@ -172,5 +172,5 @@ class IncusClient(object):
         """List instances from Incus.
         Returns a list of instances in a dict.
         """
-        data = self._execute('list', '--format', 'json', filter)
+        data = self._execute('list', '--project', self.project, '--format', 'json', filter)
         return json.loads(data)


### PR DESCRIPTION
I wanted to try to use the inventory plugin from this collection but I noticed that it was not working correctly since I was using a custom project.