### PR TITLE
Use the instance_name as ansible_host when using incus connection

### DIFF
--- a/plugins/inventory/incus.py
+++ b/plugins/inventory/incus.py
@@ -292,6 +292,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
                 # FIXME: vlanid
                 self.inventory.set_variable(instance_name, 'ansible_incus_vlan_ids', None)
             if instance['type'] == 'container':
+                self.inventory.set_variable(instance_name, 'ansible_host', instance_name)
                 self.inventory.set_variable(instance_name, 'ansible_connection', 'community.general.incus')
             elif iface:
                 self.inventory.set_variable(instance_name, 'ansible_connection', 'ssh')


### PR DESCRIPTION
If we're using the incus connection we should use the instance name. Incus connection plugin treats the `ansible_host` as a FQDN and then split it in order to use the leading part as the instance name

https://github.com/ansible-collections/community.general/blob/b2b8fc30bf9bbccb8cab06a21833d2d7a179435b/plugins/connection/incus.py#L83-L86

Since we already have the instance name, just use that.

This would be true also for VMs that have the `incus-agent` running, but
it requires more experimentation and we can fix it later.