### PR TITLE
chore: Fix dependency map

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,7 +41,7 @@ tags: []
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies: {
-  community.general": "*"
+  "community.general": "*"
 }
 
 # The URL of the originating SCM repository


### PR DESCRIPTION
Previous commit caused syntax error in galaxy.yml. This fixes the installation.