### PR TITLE
Add back default parameter value for IncusClient list function

### DIFF
--- a/plugins/module_utils/incuscli.py
+++ b/plugins/module_utils/incuscli.py
@@ -162,7 +162,7 @@ class IncusClient(object):
         if data.get('status_code', 500) != 200:
             raise IncusClientException('Failed to delete profile', **data)
 
-    def list(self, filter):
+    def list(self, filter=''):
         """List instances from Incus.
         Returns a list of instances in a dict.
         """


### PR DESCRIPTION
Here https://github.com/kmpm/ansible-collection-incus/commit/8a67494227c24b7c677bb91bee3d2a9642582543#diff-200f3210b107b41966771591776595947c443cad9cdc394a569c3c5c63bf0c0eL171-R165 while removing type hints the default value was removed as well.