### PR TITLE
fix: creation of virtual machine instances

### DIFF
--- a/plugins/modules/incus_instance.py
+++ b/plugins/modules/incus_instance.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 
@@ -345,8 +346,8 @@ import datetime
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.kmpm.incus.plugins.module_utils.incuscli import IncusClient, IncusClientException
-
+from ansible_collections.kmpm.incus.plugins.module_utils.incuscli import (
+    IncusClient, IncusClientException)
 
 # INCUS_ANSIBLE_STATES is a map of states that contain values of methods used
 # when a particular state is evoked.
@@ -726,7 +727,7 @@ def main():
             type=dict(
                 type='str',
                 default='container',
-                choices=['container', 'vm'],
+                choices=['container', 'virtual-machine'],
             ),
             wait_for_container=dict(
                 type='bool',


### PR DESCRIPTION
Hi!

First off, thanks for the work to make this collection! I've found it really helpful.

I was struggling to provision a VM though - it looks like it's a simple validation failure and it works with the attached patch.

```shellsession
% incus version
Client version: 6.7
Server version: 6.0.2
```


---

* fix: creation of virtual machine instances (4267852)
      
      The incus_instance task would only allow "container" and "vm" to be
      passed as the instance type, but using "vm" would rest in a server
      error:
      
          Unexpected instance type "vm"
      
      The argument sent by the CLI is "virtual-machine":
      
          {
                  "architecture": "",
                  "config": {},
                  "devices": {},
                  "ephemeral": false,
                  "profiles": null,
                  "stateful": false,
                  "description": "",
                  "name": "bananas",
                  "source": {
                          "type": "image",
                          "certificate": "",
                          "alias": "debian/bookworm/cloud",
                          "server": "https://images.linuxcontainers.org",
                          "protocol": "simplestreams",
                          "mode": "pull",
                          "allow_inconsistent": false
                  },
                  "instance_type": "",
            -->   "type": "virtual-machine",   <--
                  "start": true
          }
      
      This commit fixes the validation logic to allow the correct VM instance
      type to be sent.

