### PR TITLE
fix: add remote to all modules

### DIFF
--- a/plugins/module_utils/incuscli.py
+++ b/plugins/module_utils/incuscli.py
@@ -35,6 +35,10 @@ class IncusClient(object):
         if not self._incus_cmd:
             raise IncusClientException("incus command not found in PATH")
 
+    def _remoteCmd(self, cmd):
+        """Return the command with the remote set."""
+        return [cmd, self.remote + ':']
+
     def _parseErr(self, returncode, stderr):
         err_params = {"rc": returncode}
         if self.debug:
@@ -70,7 +74,8 @@ class IncusClient(object):
             url = url + '&' + urlencode(url_params)
         else:
             url = url + '?' + urlencode(url_params)
-
+        if self.remote != 'local':
+            url = self.remote + ':' + url
         args = ['query', '-X', method, url, '--wait', '--raw']
         if self.debug:
             self.logs.append(args)
@@ -167,9 +172,7 @@ class IncusClient(object):
         Returns a list of instances in a dict.
         """
         # syntax: incus list [<remote>:] [<filter>...] [flags]
-        args=['list',]
-        if self.remote:
-            args.extend([self.remote + ':',])
+        args = self._remoteCmd('list')
         if filter:
             args.extend([filter, ]),
         args.extend(['--project', self.project, '--format', 'json'])

--- a/plugins/modules/incus_instance.py
+++ b/plugins/modules/incus_instance.py
@@ -30,6 +30,10 @@ options:
           - Name of an instance.
         type: str
         required: true
+    remote:
+        description: The remote to use for the Incus CLI.
+        type: str
+        default: local
     description:
         description:
             - Description of the instance
@@ -387,6 +391,8 @@ class IncusInstanceManagement(object):
         self.module = module
         self.name = self.module.params['name']
         self.project = self.module.params['project']
+        self.description = self.module.params['description']
+        self.remote = self.module.params['remote']
         self._build_config()
 
         self.state = self.module.params['state']
@@ -405,6 +411,7 @@ class IncusInstanceManagement(object):
         try:
             self.client = IncusClient(
                 project=self.project,
+                remote=self.remote,
                 debug=self.debug
             )
         except IncusClientException as e:
@@ -682,6 +689,10 @@ def main():
             name=dict(
                 type='str',
                 required=True,
+            ),
+            remote=dict(
+                type='str',
+                default='local',
             ),
             description=dict(
                 type='str',

--- a/plugins/modules/incus_instance_info.py
+++ b/plugins/modules/incus_instance_info.py
@@ -23,6 +23,10 @@ options:
             - Name of the instance. If empty all instances will be returned.
         type: str
         required: false
+    remote:
+        description: The remote to use for the Incus CLI.
+        type: str
+        default: local
     project:
         description:
             - Project to get network information from
@@ -89,10 +93,11 @@ class IncusInstanceInfo(object):
     def __init__(self, module):
         self.module = module
         self.name = module.params['name']
+        self.remote = module.params['remote']
         self.project = module.params['project']
         self.target = module.params['target']
 
-        self.client = IncusClient(project=self.project, target=self.target)
+        self.client = IncusClient(project=self.project, target=self.target, remote=self.remote)
         self.api_endpoint = '/1.0/instances'
         self.logs = []
 
@@ -152,6 +157,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=False),
+            remote=dict(type='str', default='local'),
             project=dict(type='str', default='default'),
             target=dict(type='str', required=False),
         ),

--- a/plugins/modules/incus_network.py
+++ b/plugins/modules/incus_network.py
@@ -20,6 +20,10 @@ options:
             - Name of the network
         type: str
         required: true
+    remote:
+        description: The remote to use for the Incus CLI.
+        type: str
+        default: local
     project:
         description:
             - Project to manage the network in
@@ -259,6 +263,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=True),
+            remote=dict(type='str', default='local'),
             project=dict(type='str', default='default'),
             description=dict(type='str', required=False),
             config=dict(type='dict', required=False),

--- a/plugins/modules/incus_network_info.py
+++ b/plugins/modules/incus_network_info.py
@@ -23,6 +23,10 @@ options:
             - Name of the network. If empty all networks will be returned.
         type: str
         required: false
+    remote:
+        description: The remote to use for the Incus CLI.
+        type: str
+        default: local
     project:
         description:
             - Project to get network information from
@@ -84,8 +88,9 @@ class IncusNetworkInfo(object):
         self.name = module.params['name']
         self.project = module.params['project']
         self.target = module.params['target']
+        self.remote = module.params['remote']
 
-        self.client = IncusClient(project=self.project, target=self.target)
+        self.client = IncusClient(project=self.project, target=self.target, remote=self.remote)
         self.api_endpoint = '/1.0/networks'
         self.logs = []
 
@@ -145,6 +150,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=False),
+            remote=dict(type='str', default='local'),
             project=dict(type='str', default='default'),
             target=dict(type='str', required=False),
         ),

--- a/plugins/modules/incus_profile.py
+++ b/plugins/modules/incus_profile.py
@@ -20,6 +20,10 @@ options:
             - Name of the profile
         type: str
         required: true
+    remote:
+        description: The remote to use for the Incus CLI.
+        type: str
+        default: local
     project:
         description:
             - Project to manage the profile in
@@ -86,13 +90,15 @@ def clean_resource(resource, **defaults):
 class IncusProfileManagement(object):
     def __init__(self, module):
         self.module = module
-        self.client = IncusClient(module.params['project'])
-
+        self.remote = self.module.params['remote']
+        self.project = module.params['project']
         self.name = self.module.params['name']
         self.description = self.module.params['description']
         self.config = self.module.params['config']
         self.devices = self.module.params['devices']
         self.state = self.module.params['state']
+
+        self.client = IncusClient(project=self.project, remote=self.remote)
         self.actions = []
 
     def _get_current(self):
@@ -175,6 +181,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=True),
+            remote=dict(type='str', default='local'),
             project=dict(type='str', default='default'),
             description=dict(type='str', required=False),
             config=dict(type='dict', required=False, default={}),

--- a/tests/unit/plugins/module_utils/test_incuscli.py
+++ b/tests/unit/plugins/module_utils/test_incuscli.py
@@ -14,7 +14,7 @@ except ImportError:
     from mock import patch
 
 # from ansible_collections.community.general.tests.unit.compat.mock import patch
-from ansible_collections.kmpm.incus.plugins.module_utils.incuscli import IncusClient
+from ansible_collections.kmpm.incus.plugins.module_utils.incuscli import IncusClient, ensure_remote
 
 
 @patch("ansible_collections.kmpm.incus.plugins.module_utils.incuscli.get_bin_path", side_effect=ValueError('boom'))
@@ -32,3 +32,10 @@ def test_instanciation(_get_bin_path):
     client = IncusClient()
     _get_bin_path.assert_called_once()
     assert client is not None
+
+
+def test_ensure_remote():
+    assert ensure_remote('local') == 'local:'
+    assert ensure_remote('local:') == 'local:'
+    with pytest.raises(ValueError):
+        ensure_remote('loc al')


### PR DESCRIPTION
Make `remote` an optional argument to all modules, including the inventory module.
It will be set to 'local' as default and it should always be used to avoid that a changed default in the incus client affects what happens.