### PR TITLE
Fix listing instances for all projects vs specified projects.

### DIFF
--- a/plugins/module_utils/incuscli.py
+++ b/plugins/module_utils/incuscli.py
@@ -184,8 +184,16 @@ class IncusClient(object):
         """
         # syntax: incus list [<remote>:] [<filter>...] [flags]
         args = ['list', ensure_remote(self.remote)]
+
         if filter:
             args.extend([filter, ]),
-        args.extend(['--project', self.project, '--format', 'json'])
+
+        if self.project == 'all':
+            args.extend(['--all-projects'])
+        else:
+            args.extend(['--project', self.project])
+
+        args.extend(['--format', 'json'])
+
         data = self._execute(*args)
         return json.loads(data)


### PR DESCRIPTION
Hi,

This is a little fix for listing instances for all projects.  Currently filtering for 'all' projects in the inventory plugin doesn't really work.  This partially fixes things.  I think the other part is that the inventory plugin uses `self.project` a bunch when it should be `self.project_filter` but I'm not certain on what the intent was there so I haven't committed a change to that effect.