### PR TITLE
Let Ansible warn about bad group names.

### DIFF
--- a/plugins/inventory/incus.py
+++ b/plugins/inventory/incus.py
@@ -283,9 +283,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
         if self.groupby:
             for group_name in self.groupby:
-                if not group_name.isalnum():
-                    raise AnsibleParserError('Invalid character(s) in groupname: {0}'.format(to_native(group_name)))
-
                 if self.groupby[group_name]:
                     group_type = self.groupby[group_name].get('type', group_name)
                 else:


### PR DESCRIPTION
I'd suggest completely removing the groupby var check since Ansible tests this stuff itself (kind of, it warns about it anyway).

If you wanted to keep throwing an error on invalid group names, it might be better to use `ansible.constants.INVALID_VARIABLE_NAMES` to determine if the group name is valid or not.

As it stands, the existing test excludes legitimate group names, such as names with underscores in them.